### PR TITLE
Show API filter feat on about page

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -2,6 +2,8 @@ import Layout from "../components/MyLayout";
 const About = () => (
     <Layout>
       <h1>About Page</h1>
+      <p> Go to http://localhost:3000/quotes?author=rauch in your browser to see
+        this serverless API feat in action. The API fetches quotes filtered by author= Rauch in this case</p>
     </Layout>
 )
 


### PR DESCRIPTION
Show URL on the about page. To see the serverless API feat of next.js in action